### PR TITLE
Bug at fuse_impl.py: For entry.st_nlink >1 (example: on multiple hard links to an inode) the _remove fails to remove dentry.

### DIFF
--- a/Telegram/fuse_impl.py
+++ b/Telegram/fuse_impl.py
@@ -260,6 +260,11 @@ class Operations(pyfuse3.Operations):
             # Delete from telegram_messages
             self.cursor.execute("DELETE FROM telegram_messages where inode=?", (entry.st_ino,))
 
+        if entry.st_nlink > 1 and entry.st_ino not in self.inode_open_count:
+            # delete from contents
+            self.cursor.execute("DELETE FROM contents WHERE name=? AND parent_inode=?",
+                            (name, inode_p))
+
         self.db.commit()
 
     async def symlink(self, inode_p, name, target, ctx):


### PR DESCRIPTION
Consider the following contents table entry:

| name                       | inode | parent_inode |
|----------------------------|-------|--------------|
| myfile                     | 5     | 2            |
| hardlink_to_myfile         | 5     | 3            |
| another_hardlink_to_myfile | 5     | 2            |

Now if I try to delete one of the links, say hardlink_to_myfile, then the operation fails because entry.st_nlink > 1 and the conditional at line 249 in fuse_impl.py is never reached.
So, I propose to add another conditional at entry.st_nlink > 1 where only the dentry is deleted.